### PR TITLE
BACKLOG-12866: Add toggleNode to TreeView onClickItem prop

### DIFF
--- a/src/javascript/Dashboard/Dashboard.jsx
+++ b/src/javascript/Dashboard/Dashboard.jsx
@@ -62,7 +62,7 @@ export const DashBoard = ({match}) => {
                                                   history.push(app.route || ('/dashboard/' + app.id)) :
                                                   toggleNode(event)
                                           )
-}/>
+                                      }/>
                         </AccordionItem>
                     </Accordion>
                 </SecondaryNav>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12866

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

The onClickItem prop for the TreeView component now uses the toggleNode method which is passed through to toggle open/close of the node if it's not selectable as per the data object.

This PR cannot be merged until the supporting change from MOON-131 is included in a Moonstone release.
