### PR TITLE
Fixed repo-linter

### DIFF
--- a/.github/workflows/repo-linter.yml
+++ b/.github/workflows/repo-linter.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install ruby and gem
         run: sudo apt-get install -y ruby bundler cmake pkg-config git libssl-dev       
       - name: Install repolinter
-        run: npm install repolinter
+        run: npm install repolinter is-windows
       - name: Install licensee
         run: sudo gem install licensee
       - name: Run repolinter


### PR DESCRIPTION
There was apparently a change in repo-linter, and it started failing on various repositories because is-windows is missing.