### PR TITLE
QA-13676 Merge queries to make sure useQuery hook handles errors corr…

### DIFF
--- a/src/javascript/Dashboard/HomeScreen/HomeScreen.gql-queries.jsx
+++ b/src/javascript/Dashboard/HomeScreen/HomeScreen.gql-queries.jsx
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag';
 import {PredefinedFragments} from '@jahia/data-helper';
 
-const DashboardQuery = gql`
-    query WelcomeScreen {
+const WelcomeScreenWithPermissions = gql`
+    query WelcomeScreenWithPermissions {
         dashboard {
             toolsAccess
             modules {
@@ -13,11 +13,6 @@ const DashboardQuery = gql`
                 inDevelopment
             }
         }
-    }
-`;
-
-const PermissionsQuery = gql`
-    query WelcomeScreenPermissions {
         jcr {
             rootNode: nodeByPath(path: "/") {
                 studioModeAccess: hasPermission(permissionName: "studioModeAccess")
@@ -29,4 +24,4 @@ const PermissionsQuery = gql`
     ${PredefinedFragments.nodeCacheRequiredFields.gql}
 `;
 
-export {DashboardQuery, PermissionsQuery};
+export {WelcomeScreenWithPermissions};

--- a/src/javascript/Dashboard/HomeScreen/HomeScreen.jsx
+++ b/src/javascript/Dashboard/HomeScreen/HomeScreen.jsx
@@ -7,7 +7,7 @@ import Documentation from './Documentation';
 import classnames from 'clsx';
 import styles from './HomeScreen.scss';
 import {useQuery} from '@apollo/react-hooks';
-import {DashboardQuery, PermissionsQuery} from './HomeScreen.gql-queries';
+import {WelcomeScreenWithPermissions} from './HomeScreen.gql-queries';
 import {ProgressOverlay} from '@jahia/react-material';
 import {useTranslation} from 'react-i18next';
 import {useSelector} from 'react-redux';
@@ -16,50 +16,28 @@ import Spacing from './Spacing';
 const HomeScreen = () => {
     const {t} = useTranslation('jahia-dashboard');
     const locale = useSelector(state => state.uilang);
-    const dashboardData = useQuery(DashboardQuery, {
-        variables: {
-        },
-        fetchPolicy: 'network-only'
-    });
+    const {error, data, loading} = useQuery(WelcomeScreenWithPermissions, {fetchPolicy: 'network-only'});
 
-    const permissionsData = useQuery(PermissionsQuery, {
-        variables: {
-        },
-        fetchPolicy: 'network-only'
-    });
-
-    if (dashboardData.error) {
+    if (error) {
         const message = t(
             'jahia-dashboard:jahia-dashboard.error.queryingContent',
-            {details: dashboardData.error.message ? dashboardData.error.message : ''}
+            {details: error.message ? error.message : ''}
         );
-        return <>{message}</>;
+        return <p>{message}</p>;
     }
 
-    if (dashboardData.loading) {
+    if (loading) {
         return <ProgressOverlay/>;
     }
 
-    if (permissionsData.error) {
-        const message = t(
-            'jahia-dashboard:jahia-dashboard.error.queryingContent',
-            {details: permissionsData.error.message ? permissionsData.error.message : ''}
-        );
-        return <>{message}</>;
-    }
-
-    if (permissionsData.loading) {
-        return <ProgressOverlay/>;
-    }
-
-    const modules = dashboardData.data.dashboard.modules;
+    const modules = data.dashboard.modules;
     const myModules = modules.filter(module => module.inDevelopment === true);
 
     const availableModules = modules.map(module => module.id);
     const operatingMode = window.contextJsParameters.config.operatingMode;
 
-    const hasStudioAccessPermission = permissionsData.data.jcr.rootNode.studioModeAccess;
-    const hasAdminVirtualSitesPermission = permissionsData.data.jcr.rootNode.adminVirtualSites;
+    const hasStudioAccessPermission = data.jcr.rootNode.studioModeAccess;
+    const hasAdminVirtualSitesPermission = data.jcr.rootNode.adminVirtualSites;
 
     const developmentMode = operatingMode === 'development' && hasStudioAccessPermission;
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13676

## Description

Make sure that when one query fails and second one runs ok it doesn't ignore errors of the previous query. Must be a useQuery hook issue but as long as first one fails before second one completes the first one loses its state and all returns are undefined which makes the app crash. 
