### PR TITLE
BACKLOG-16171: Revert "[skip ci] [maven-release-plugin]prepare release 1_4_0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,11 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.0.0</version>
+        <version>8.1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jahia-dashboard</artifactId>
     <name>jahia-dashboard</name>
-    <version>1.4.0</version>
+    <version>1.4.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (jahia-dashboard) for running on a Jahia server.</description>
 
@@ -61,7 +61,7 @@
         <connection>scm:git:https://github.com/Jahia/jahia-dashboard</connection>
         <developerConnection>scm:git:git@github.com:Jahia/jahia-dashboard.git</developerConnection>
         <url>https://github.com/Jahia/jahia-dashboard</url>
-        <tag>1_4_0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>graphql-dxm-provider</artifactId>
-            <version>2.7.0</version>
+            <version>2.7.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
This reverts commit dc1ccd1e27084f370f9853fbe01ae7cb1b404032.

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16171

Last re-run failed because of existing tag. Need to revert again.