### PR TITLE
ci(release): Fix reusable workflow

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-module:
-    uses: Jahia/jahia-modules-action/.github/workflows/release-module.yml@v2
-    secrets: inherit 
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-release-module.yml@v2
+    secrets: inherit
     with:
       primary_release_branch: "master"


### PR DESCRIPTION
## Description

Use the reusable workflow for the release process (was pointing at a workflow that got removed in https://github.com/Jahia/jahia-modules-action/pull/228).
I came across this issue while releasing Module Manager (see https://github.com/Jahia/module-manager/pull/163) as I realised more repositories are impacted: https://github.com/search?q=org%3AJahia+Jahia%2Fjahia-modules-action%2F.github%2Fworkflows%2Frelease-module.yml&type=code.
